### PR TITLE
AbstractAcceptanceTest integrationtest fix for vs2019

### DIFF
--- a/Source/FunctionMonkey/ConfigurationLocator.cs
+++ b/Source/FunctionMonkey/ConfigurationLocator.cs
@@ -40,7 +40,7 @@ namespace FunctionMonkey
 
         private static bool Scan(out MethodInfo linkBackInfo, out IFunctionAppConfiguration findConfiguration)
         {
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.GetName().Name.StartsWith("Microsoft.")).ToArray();
             linkBackInfo = null;
             findConfiguration = null;
 


### PR DESCRIPTION
the new vs2019 (16.2.0) test explorer has an issue with GetAssemblies when it tries to load internal test assemblies
https://github.com/microsoft/vstest/issues/2008

with this fix the Microsoft assemblies are not loaded when an integration test runs (FunctionMonkey.Testing.AbstractAcceptanceTest)