### PR TITLE
Fix bug on openapi compiler when using http delete method.

### DIFF
--- a/Source/FunctionMonkey.Compiler/Implementation/OpenApiCompiler.cs
+++ b/Source/FunctionMonkey.Compiler/Implementation/OpenApiCompiler.cs
@@ -246,7 +246,7 @@ namespace FunctionMonkey.Compiler.Implementation
                             }
                         }
 
-                        if (functionByRoute.Authorization == AuthorizationTypeEnum.Function  && method == HttpMethod.Get || method == HttpMethod.Delete)
+                        if (functionByRoute.Authorization == AuthorizationTypeEnum.Function  && (method == HttpMethod.Get || method == HttpMethod.Delete))
                         {
                             operation.Parameters.Add(new OpenApiParameter
                             {


### PR DESCRIPTION
Hey James, 
I found a little bug when working with FunctionMonkey. You missed some brackets on the if statement at the OpenAPI compiler. Otherwise the `code` parameter on the _HTTP delete method_ is always displayed at the swagger specification independently from the authorization type. I guess that should not be the case.
Great work and keep going!

Regards Mathias 