### PR TITLE
Newtonsoft.Json version and property names in ConvertErrors task

### DIFF
--- a/Source/FunctionMonkey.Compiler.MSBuild/FunctionMonkey.Compiler.MSBuild.csproj
+++ b/Source/FunctionMonkey.Compiler.MSBuild/FunctionMonkey.Compiler.MSBuild.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 
 </Project>

--- a/Source/FunctionMonkey.Compiler/FunctionMonkey.Compiler.targets
+++ b/Source/FunctionMonkey.Compiler/FunctionMonkey.Compiler.targets
@@ -42,11 +42,11 @@
   <Target Name="_FunctionMonkeyAzureFunctionsPublishCompiler" AfterTargets="_GenerateFunctionsAndCopyContentFiles" Condition="'$(AzureFunctionsVersion)' != ''">
     <Message Text="Running Function Monkey in Publish location $(PublishDir) for Azure Functions" />
     <Exec Command="$(FunctionCompilerExe) &quot;$(PublishDir)$(FunctionPublishParams)&quot; $(FunctionPublishPostfix)" />
-    <ConvertErrors InputAssemblyPath="$(FunctionPublishParams)" />
+    <ConvertErrors InputPath="$(FunctionPublishParams)" /> 
   </Target>
   <Target Name="_FunctionMonkeyAspNetPublishCompiler" AfterTargets="AfterPublish" Condition="'$(AzureFunctionsVersion)' == ''">
     <Message Text="Running Function Monkey in Publish location $(PublishDir) for ASP.Net Core" />
     <Exec Command="$(FunctionCompilerExe) &quot;$(PublishDir)$(FunctionPublishParams)&quot; $(FunctionPublishPostfix)" />
-    <ConvertErrors InputAssemblyPath="$(FunctionPublishParams)" />
+    <ConvertErrors InputPath="$(FunctionPublishParams)" />
   </Target>
 </Project>


### PR DESCRIPTION
Disclaimer: Only trying the 4 beta, so you might be on top of this. But I had to do it in order to get to publish.  
I've managed to make the compile step "work" in VS19 by manually copying in the assembly with this changes to the %user%\.nuget\… folder.  
However, dotnet CLI and VS publish still fails for weird reasons. Seems it still can't find Newtonsoft.Json 12.  
In order to get anything through, I comment out the ConvertErrors steps in the build targets file for now.

Shout if you want some logs, but it's really just "Can't find Newtonsoft.Json 12". ;)