### PR TITLE
changed response for SignalR negotiate to use Microsoft.Azure.SignalR…

### DIFF
--- a/Source/FunctionMonkey.Compiler.Core/Templates/AzureFunctions/signalrclaimnegotiate.csharp.handlebars
+++ b/Source/FunctionMonkey.Compiler.Core/Templates/AzureFunctions/signalrclaimnegotiate.csharp.handlebars
@@ -13,7 +13,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using FunctionMonkey.Abstractions.Builders.Model;
 using System.Security.Claims;
-using FunctionMonkey.SignalR;
 
 namespace {{Namespace}}
 {
@@ -89,15 +88,17 @@ namespace {{Namespace}}
             string userId = principal.FindFirst(claim => claim.Type == "{{{ClaimType}}}").Value;
             return CreateSignalRResponse(userId);
         }
-        
+
         public static IActionResult CreateSignalRResponse(string userId)
         {
-            List<Claim> claims = new List<Claim>();
-            claims.Add(new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", userId));
-
-            AzureSignalRAuthClient client = new AzureSignalRAuthClient(System.Environment.GetEnvironmentVariable("{{ConnectionStringSettingName}}"));
-            SignalRConnectionInfo info = client.GetClientConnectionInfo("{{{HubName}}}", claims);
-            return new OkObjectResult(info);
+            var connectionInfo = new SignalRConnectionInfo();
+            var serviceManager = StaticServiceHubContextStore.Get("{{ConnectionStringSettingName}}").ServiceManager;
+            connectionInfo.AccessToken = serviceManager
+                .GenerateClientAccessToken(
+                    "{{HubName}}",
+                    userId);
+            connectionInfo.Url = serviceManager.GetClientEndpoint("{{HubName}}");
+            return new OkObjectResult(connectionInfo);
         }
 
         private static string GetRequestUrl(HttpRequest request)

--- a/Source/FunctionMonkey.Compiler.Core/Templates/AzureFunctions/signalrcommandnegotiate.csharp.handlebars
+++ b/Source/FunctionMonkey.Compiler.Core/Templates/AzureFunctions/signalrcommandnegotiate.csharp.handlebars
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using FunctionMonkey.Abstractions.Builders.Model;
-using FunctionMonkey.SignalR;
 using System.Security.Claims;
 
 namespace {{Namespace}}
@@ -494,15 +493,14 @@ namespace {{Namespace}}
 
         public static IActionResult CreateSignalRResponse(FunctionMonkey.Commanding.Abstractions.SignalRNegotiateResponse commandResponse)
         {
-            List<Claim> claims = new List<Claim>();
-            if (!string.IsNullOrWhiteSpace(commandResponse.UserId))
-            {
-                claims.Add(new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", commandResponse.UserId));
-            }
-
-            AzureSignalRAuthClient client = new AzureSignalRAuthClient(System.Environment.GetEnvironmentVariable("{{ConnectionStringSettingName}}"));
-            SignalRConnectionInfo info = client.GetClientConnectionInfo(commandResponse.HubName, claims);
-            return new OkObjectResult(info);
+            var connectionInfo = new SignalRConnectionInfo();
+            var serviceManager = StaticServiceHubContextStore.Get("{{ConnectionStringSettingName}}").ServiceManager;
+            connectionInfo.AccessToken = serviceManager
+                .GenerateClientAccessToken(
+                    commandResponse.HubName,
+                    commandResponse.UserId);
+            connectionInfo.Url = serviceManager.GetClientEndpoint(commandResponse.HubName);
+            return new OkObjectResult(connectionInfo);
         }
 
         public static IActionResult CreateResponse(int code, object content, FunctionMonkey.PluginFunctions pluginFunctions)


### PR DESCRIPTION
….Management

You can also now remove AzureSignalRAuthClient class as it is not used anymore.
Maybe move a content of FunctionMonkey.SignalR to FunctionMonkey...