### PR TITLE
Fix stream blob storage with output bindings compilation error

### DIFF
--- a/Source/FunctionMonkey.Compiler.Core/Templates/AzureFunctions/storageblobstream.csharp.handlebars
+++ b/Source/FunctionMonkey.Compiler.Core/Templates/AzureFunctions/storageblobstream.csharp.handlebars
@@ -29,6 +29,7 @@ namespace {{Namespace}}
         {
             log.LogInformation("Storage blob stream function {{Name}} processed a request.");
             FunctionMonkey.Runtime.FunctionProvidedLogger.Value = log;
+            FunctionMonkey.PluginFunctions pluginFunctions = FunctionMonkey.Runtime.PluginFunctions["{{Name}}"];
 
             {{CommandTypeName}} command = new {{CommandTypeName}} {
                 Stream = stream,


### PR DESCRIPTION
Stream blob storage functions will fail to compile if you try to use output bindings with them because `pluginFunctions` cannot be found. This PR resolves that by adding it to the template. 